### PR TITLE
fixed leaks, invalid read and open fds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: kdaumont <kdaumont@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/11/22 11:07:12 by aattali           #+#    #+#              #
-#    Updated: 2024/02/05 11:02:14 by kdaumont         ###   ########.fr        #
+#    Updated: 2024/02/21 13:08:40 by aattali          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -21,7 +21,7 @@ TARGET := minishell
 #* ************************************************************************** *#
 
 CC := clang
-CFLAGS += -Wall -Werror -Wextra 
+CFLAGS += -Wall -Werror -Wextra
 LIBRARY_FLAGS := -L/usr/lib -Lmlx -lXext -lX11 -lz -lm -lreadline
 
 #* ************************************************************************** *#
@@ -226,6 +226,13 @@ gmk:
 norm:
 	@norminette $(LIBFT_DIR)
 	@norminette $(SRCDIR) $(INCLUDES)
+
+vg: debug
+	valgrind --track-origins=yes --leak-check=full --suppressions=readline.supp ./minishell
+
+vgc: debug
+	valgrind --track-origins=yes --leak-check=full --track-fds=yes --trace-children=yes --suppressions=readline.supp ./minishell
+
 # --------------------- #
 #      Recompile.       #
 # --------------------- #
@@ -246,4 +253,4 @@ sanadd: all
 
 santhread: all
 
-.PHONY: bonus clean fclean fcleanlib gmk re relib noflag debug optimize sanadd santhread norm
+.PHONY: bonus clean fclean fcleanlib gmk re relib noflag debug optimize sanadd santhread norm vg vgc

--- a/readline.supp
+++ b/readline.supp
@@ -1,0 +1,14 @@
+{
+    _readline_
+        Memcheck:Leak
+        match-leak-kinds: all
+        ...
+        fun:readline
+}
+{
+    _add_history_
+        Memcheck:Leak
+        match-leak-kinds: all
+        ...
+        fun:add_history
+}  

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -6,7 +6,7 @@
 /*   By: aattali <aattali@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/05 10:00:41 by aattali           #+#    #+#             */
-/*   Updated: 2024/02/20 09:43:09 by aattali          ###   ########.fr       */
+/*   Updated: 2024/02/21 13:10:12 by aattali          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -119,5 +119,7 @@ int	the_executor(t_executor *executor, t_commands *command)
 			handle_forking(command, executor);
 		command = command->next;
 	}
+	dup2(executor->saved_stdin, STDIN_FILENO);
+	close(executor->saved_stdin);
 	return (wait_childs(executor));
 }

--- a/src/executor/forking.c
+++ b/src/executor/forking.c
@@ -6,7 +6,7 @@
 /*   By: aattali <aattali@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/14 08:57:20 by aattali           #+#    #+#             */
-/*   Updated: 2024/02/21 11:23:03 by aattali          ###   ########.fr       */
+/*   Updated: 2024/02/21 13:09:32 by aattali          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -114,6 +114,7 @@ void	execute(t_commands *command, t_executor *executor)
 {
 	char	**env;
 
+	close(executor->saved_stdin);
 	setup_fd(command, executor);
 	if (get_path(command, executor) == -1)
 		clean_exit(MALLOC_ERROR, executor, 0);

--- a/src/handler.c
+++ b/src/handler.c
@@ -6,7 +6,7 @@
 /*   By: aattali <aattali@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/19 11:32:25 by aattali           #+#    #+#             */
-/*   Updated: 2024/02/20 14:33:34 by aattali          ###   ########.fr       */
+/*   Updated: 2024/02/21 13:11:00 by aattali          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,24 @@
 int	malloc_error(void)
 {
 	return (ft_dprintf(STDERR_FILENO, MALLOC_ERROR), EXIT_FAILURE);
+}
+
+/**
+ * @brief free the two linked-lists and the exec struct
+ *
+ * @param lex the linked list of lexed elements
+ * @param exec the struct of the exec process
+ * @param cmd the linked list of commands
+ */
+static void	clean_posthandle(t_lexer **lex, t_executor *exec, t_commands **cmd)
+{
+	lex_clear(lex);
+	free(exec->outfn);
+	free(exec->infn);
+	free(exec->limiter);
+	ft_free_astr(exec->path);
+	free(exec);
+	cmd_clear(cmd);
 }
 
 /**
@@ -50,4 +68,5 @@ void	handler(char *line, t_minishell *minishell)
 	}
 	executor->env = &(minishell->env);
 	minishell->code = the_executor(executor, command);
+	clean_posthandle(&lex, executor, &command);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: aattali <aattali@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/19 11:37:43 by aattali           #+#    #+#             */
-/*   Updated: 2024/02/21 11:20:05 by aattali          ###   ########.fr       */
+/*   Updated: 2024/02/21 12:51:03 by aattali          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -85,7 +85,7 @@ static int	dispatch(t_lexer *node, t_executor *exec, t_commands **cmd, int *i)
 		if (!tmp)
 		{
 			len = cmdlen(node);
-			tmp = ft_calloc(len, sizeof(*tmp));
+			tmp = ft_calloc(len + 1, sizeof(*tmp));
 			if (!tmp)
 				return (malloc_error());
 		}

--- a/src/parser/parser_handlers.c
+++ b/src/parser/parser_handlers.c
@@ -6,7 +6,7 @@
 /*   By: aattali <aattali@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/20 09:01:58 by aattali           #+#    #+#             */
-/*   Updated: 2024/02/20 14:34:09 by aattali          ###   ########.fr       */
+/*   Updated: 2024/02/21 12:40:39 by aattali          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -115,6 +115,8 @@ int	io_handler(t_lexer **node, t_executor *executor, t_commands **command)
 		}
 		if (!io_sl(*node, executor, command, str))
 			return (EXIT_SUCCESS);
+		if (!(*node)->next)
+			break ;
 		*node = (*node)->next;
 	}
 	return (EXIT_SUCCESS);


### PR DESCRIPTION
- correctly restore the saved stdin after the execution process
- close the saved stdin after forking and after restoring for the parent
- allocate len + 1 for the array of cmd given to execve, because it needs to be null terminated
- if the io_handler for parsing is the last node, fast exit and let the dispatcher update the last node to avoid invalid reads
- added ``make vg`` to launch valgrind with the suppression file to ignore the readline errors
- added ``make vgc`` that does the same thing above and track fds and childrens (there will be un-suppressed errors for the commands that can leak, like grep or cat)